### PR TITLE
Removing history when scrolling

### DIFF
--- a/static/js/docs.js
+++ b/static/js/docs.js
@@ -321,11 +321,12 @@ $(function() {
 
     if(newHashId && newHashId != currentHashId) {
 
+      // disable history push state for right side menu items
       if(history.pushState) {
-        history.pushState(null, null, '#' + newHashId)
+        // history.pushState(null, null, '#' + newHashId)
       }
       else {
-        location.hash = '#' + activeElement.attr('id')
+        // location.hash = '#' + activeElement.attr('id')
       }
     }
   }


### PR DESCRIPTION
Current Behaviour:

When user scrolls on docs pages, the links on right hand side gets highlighted. And when user clicks on back button, we pop the scroll action instead of user click action. This creates a confustion.

New Behaviour:
When user scrolls, the links are highlighted on right side panel. But history is not altered. Hence when user clicks back button on browser, only the user action is poppped.

Needed action 
make update-theme (if this is approved)
make develop