### PR TITLE
fix for content includes

### DIFF
--- a/layouts/shortcodes/content.html
+++ b/layouts/shortcodes/content.html
@@ -1,3 +1,4 @@
+{{ $_hugo_config := `{ "version": 1 }` }}
 {{$file := .Get 0}}
 {{$page := .Site.GetPage "page" $file }}
 {{$page.Content}}


### PR DESCRIPTION
This change must accompany a change on pxdocs to switch all `{{% content` tags to use angle brackets instead `{{< content`